### PR TITLE
fix a bug that overstated time left for hobbyists after midnight

### DIFF
--- a/qschedule.py
+++ b/qschedule.py
@@ -58,7 +58,10 @@ class EntrySchedule(Schedule):
         return weeknightStart - t
 
     def weeknightTimeRemaining(self, t):
-        weeknightEnd = t + relativedelta(hour=6, minute=0, second=0, microseconds=0, days=+1)
+        if t.hour >=18:
+            weeknightEnd = t + relativedelta(hour=6, minute=0, second=0, microseconds=0, days=+1)
+        else:
+            weeknightEnd = t + relativedelta(hour=6, minute=0, second=0, microseconds=0, days=0)
         return weeknightEnd - t
         
     def isWeekend(self, t):


### PR DESCRIPTION
Added one if statement to avoid the addition of a day during the
schedule description if the time is after midnight.
